### PR TITLE
Capacitor encoders tidyup

### DIFF
--- a/source/kylarLEDs/Controllers/Sensors/Encoder/Encoder.cpp
+++ b/source/kylarLEDs/Controllers/Sensors/Encoder/Encoder.cpp
@@ -58,6 +58,7 @@ void Encoder::handleInterrupt()
     // Determine the current direction
     int current_direction = gpio_get(Encoder::pinB) ? 1 : -1;
 
+    printf("Encoder direction: %d, velocity: %f, add: %d\n", current_direction, velocity, add);
     // Reset velocity if direction changes
     if (current_direction != last_direction && last_direction != 0)
     {
@@ -69,13 +70,13 @@ void Encoder::handleInterrupt()
 
     if (Encoder::accumulate)
     {
-        // If we are     // Update count based on direction
+        // If we are accumilating update count based on direction
     Encoder::count += add * current_direction;
     }
     else
     {
-        // If we are accumulating, add or subtract the count
-        Encoder::count += (current_direction ? 1 : -1);
+        // If we are not accumulating, add or subtract the count
+        Encoder::count = current_direction;
     }
 
     for (const auto &callback : Encoder::callbacks)

--- a/source/kylarLEDs/Controllers/Sensors/Encoder/Encoder.cpp
+++ b/source/kylarLEDs/Controllers/Sensors/Encoder/Encoder.cpp
@@ -16,15 +16,8 @@ Encoder::Encoder(int A, int B) : pinA(A), pinB(B), count(0)
     gpio_set_dir(B, GPIO_IN);
     gpio_pull_up(A);
     gpio_pull_up(B);
-    lock = 0; // unlocked
-    // default options
-    locktime0 = 100000; // 100ms
-    locktime = get_absolute_time() - locktime0;
-    lastB = 2; // not 0 or 1
     GPIOInterruptHandler::registerCallback(A, [this]()
-                                           { this->handleFallAInterrupt(); }, GPIO_IRQ_EDGE_FALL);
-    GPIOInterruptHandler::registerCallback(A, [this]()
-                                           { this->handleRiseAInterrupt(); }, GPIO_IRQ_EDGE_RISE);
+                                           { this->handleInterrupt(); }, GPIO_IRQ_EDGE_RISE);
 }
 
 int Encoder::getCount() const
@@ -42,65 +35,47 @@ void Encoder::clearCallbacks()
     Encoder::callbacks.clear();
 }
 
-// The encoder probably has a pull up so high is the rest state
-// So when going back to rest, we look if we should reset the lock
-// If b!=lastB then we unlock and set a new lastB
-// If you have bounce noise, keep in mind that B should be stable while A is bouncing
-// So once you remember the new lastB, this function does nothing
-// since you will be unlocked and will set lastB=b which is a NOP
-// However, we set lock=0 and lastB=b because it is cheaper than
-// deciding which one to do, if any in the case where you should unlock
-// or should remember a new lastB
-void Encoder::handleRiseAInterrupt()
+void Encoder::handleInterrupt()
 {
-    // Read the state of pinB
-    int b = gpio_get(Encoder::pinB);
+    static absolute_time_t last_time = {0};
+    static double velocity = 0; // measure how many times the encoder has been turned in the last second
+    static int last_direction = 0; // 1 for positive, -1 for negative, 0 for no movement
+    absolute_time_t new_time = get_absolute_time();
 
-    if (Encoder::lock && Encoder::lastB == b)
-        return; // not time to unlock
-    // if lock=0 and lastB==b these two lines do nothing
-    // but if lock is 1 and/or lastB!=b then one of them does something
-    Encoder::lock = 0;
-    Encoder::lastB = b;
-    Encoder::locktime = get_absolute_time() + Encoder::locktime0; // even if not locked, timeout the lastB
-}
-
-// The falling edge is where we do the count
-// Note that if you pause a bit, the lock will expire because otherwise
-// we have to monitor B also to know if a change in direction occured
-// It is tempting to try to mutually lock/unlock the ISRs, but in real life
-// the edges are followed by a bunch of bounce edges while B is stable
-// B will change while A is stable
-// So unless you want to also watch B against A, you have to make some
-// compromise and this works well enough in practice
-void Encoder::handleFallAInterrupt()
-{
-    int b;
-    // clear lock if timedout and in either case forget lastB if we haven't seen an edge in a long time
-    if (Encoder::locktime < get_absolute_time())
-    {
-        Encoder::lock = 0;
-        Encoder::lastB = 2; // impossible value so we must read this event
+    if (absolute_time_diff_us(last_time, new_time) < 2000)
+    { // 2ms debounce
+        return;
     }
-    if (lock)
-        return;                  // we are locked so done
-    b = gpio_get(Encoder::pinB); // read B
-    if (b == Encoder::lastB)
-        return;                                                   // no change in B
-    Encoder::lock = 1;                                            // don't read the upcoming bounces
-    Encoder::locktime = get_absolute_time() + Encoder::locktime0; // set up timeout for lock
-    Encoder::lastB = b;                                           // remember where B is now
 
+    uint64_t time_delta = absolute_time_diff_us(last_time, new_time);
 
-    if (!Encoder::accumulate)
+    velocity = (1000000.0 / (double)time_delta);
+    // 0 - 10 : intentional
+    // 10-20 : normal
+    // 20+ : fast
+    int add = 1 + (int)velocity / 10; // scale 
+
+    // Determine the current direction
+    int current_direction = gpio_get(Encoder::pinB) ? 1 : -1;
+
+    // Reset velocity if direction changes
+    if (current_direction != last_direction && last_direction != 0)
     {
-        // If we are not accumulating, just set count to 1 or -1
-        Encoder::count = (b ? -1 : 1);
+        velocity = 0;
+    }
+
+    last_direction = current_direction;
+    last_time = new_time;
+
+    if (Encoder::accumulate)
+    {
+        // If we are     // Update count based on direction
+    Encoder::count += add * current_direction;
     }
     else
     {
         // If we are accumulating, add or subtract the count
-        Encoder::count += (b ? -1 : 1);
+        Encoder::count += (current_direction ? 1 : -1);
     }
 
     for (const auto &callback : Encoder::callbacks)
@@ -108,34 +83,3 @@ void Encoder::handleFallAInterrupt()
         callback(Encoder::count);
     }
 }
-
-// void Encoder::handleInterrupt()
-// {
-//     absolute_time_t new_time = get_absolute_time();
-//     uint64_t time_delta = absolute_time_diff_us(last_time, new_time);
-//     // Debounce
-//     if (time_delta < 10000)
-//     {
-//         // 10ms debounce
-//         return;
-//     }
-
-//     // double velocity = 1000000.0 / static_cast<double>(time_delta);
-//     // int add = 1 + static_cast<int>(velocity / 10);
-//     int add = 1;
-//     Encoder::last_time = new_time;
-
-//     if (gpio_get(Encoder::pinB))
-//     {
-//         Encoder::count += add;
-//     }
-//     else
-//     {
-//         Encoder::count -= add;
-//     }
-
-//     for (const auto &callback : Encoder::callbacks)
-//     {
-//         callback(Encoder::count);
-//     }
-// }

--- a/source/kylarLEDs/Controllers/Sensors/Encoder/Encoder.h
+++ b/source/kylarLEDs/Controllers/Sensors/Encoder/Encoder.h
@@ -16,14 +16,11 @@ public:
     void clearCallbacks();
 
 private:
-    void handleRiseAInterrupt();
-    void handleFallAInterrupt();
+    // void handleRiseAInterrupt();
+    // void handleFallAInterrupt();
+    void handleInterrupt();
     uint8_t pinA;
     uint8_t pinB;
-    int lock;
-    uint64_t locktime0;
-    absolute_time_t locktime;
-    int lastB;
     bool accumulate = false; // if true, accumulate the count
     int count;
     std::vector<std::function<void(int)>> callbacks;


### PR DESCRIPTION
If we add capacitors and resistors to the encoder wiring, we can simplify the encoder logic and get way more accurate and fast readings. Win!